### PR TITLE
Fixes typo in defaultProps example

### DIFF
--- a/src/data/component.js
+++ b/src/data/component.js
@@ -129,14 +129,14 @@ this.forceUpdate();`,
   {
     name: "defaultProps",
     example: `class Greeting extends React.Component {
-      render() {
-        return <h1>Hi {this.props.name}</h1>
-      }
-    }
-    
-    CustomButton.defaultProps = {
-      name: 'guest'
-    };`,
+  render() {
+    return <h1>Hi {this.props.name}</h1>
+  }
+}
+
+Greeting.defaultProps = {
+  name: 'guest'
+};`,
     reference: "https://reactjs.org/docs/react-component.html#defaultprops",
   },
 ];


### PR DESCRIPTION
Previously, the example was using two different class names, which didn't make sense. I made it use a consistent class name, and cleaned up the whitespace a bit as well. 

Thanks for this resource!